### PR TITLE
Fix env parser file have multiple `=`

### DIFF
--- a/parser/env.go
+++ b/parser/env.go
@@ -32,7 +32,7 @@ func ENV(path string) error {
 		// Skip line when empty
 		v := sc.Text()
 		if len(v) != 0 {
-			env := strings.Split(v, "=")
+			env := strings.SplitN(v, "=", 2)
 
 			// get env[0] as key and env[1] as value
 			EnvMaps[env[0]] = env[1]

--- a/parser/env_test.go
+++ b/parser/env_test.go
@@ -54,4 +54,24 @@ func TestENVError(t *testing.T) {
 			t.Fail()
 		}
 	})
+
+	t.Run("success-split-string", func(t *testing.T) {
+		singleton = sync.Once{}
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("The code did panic")
+				t.Fail()
+			}
+
+			os.Remove(".env")
+		}()
+		os.WriteFile(".env", []byte("SERVER_URL=http://hostname.com?page=2&limit=10"), 0600)
+
+		env := GetENV(".env", "SERVER_URL")
+
+		if env != "http://hostname.com?page=2&limit=10" {
+			t.Error("env SERVER_URL should be http://hostname.com?page=2&limit=10")
+			t.Fail()
+		}
+	})
 }


### PR DESCRIPTION
**Issues Number** : 
- #62 

**Pull request type** :  🐞 Bug Fix

**Descriptions** :  
Fix ENV parser, separate env key and value into 2 array items

**Tests that have been done in this PR** :  

- [x] `make test` : pass  
- [x] `make lint` : pass  
- [x] `make build` : success  